### PR TITLE
Fix OPENAI_MODEL_NAME handling in UI

### DIFF
--- a/keep-ui/app/api/copilotkit/route.ts
+++ b/keep-ui/app/api/copilotkit/route.ts
@@ -12,11 +12,16 @@ export const POST = async (req: NextRequest) => {
       const openai = new OpenAI({
         organization: process.env.OPEN_AI_ORGANIZATION_ID,
         apiKey: process.env.OPEN_AI_API_KEY,
+        ...(process.env.OPENAI_BASE_URL
+          ? { baseURL: process.env.OPENAI_BASE_URL }
+          : {}),
+      });
+      const serviceAdapter = new OpenAIAdapter({
+        openai,
         ...(process.env.OPENAI_MODEL_NAME
           ? { model: process.env.OPENAI_MODEL_NAME }
           : {}),
       });
-      const serviceAdapter = new OpenAIAdapter({ openai });
       const runtime = new CopilotRuntime();
       return { runtime, serviceAdapter };
     } catch (error) {


### PR DESCRIPTION
## Summary
- use the `OPENAI_MODEL_NAME` environment variable when creating the OpenAI adapter
- allow configuring a custom base URL for LiteLLM via `OPENAI_BASE_URL`

## Testing
- `poetry run coverage run --branch -m pytest --ignore=tests/e2e_tests/` *(fails: /root/.pyenv/shims/python not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fec82f7a48328b00f4ea4aee47690