### PR TITLE
Add Centreon acknowledge step

### DIFF
--- a/docs/snippets/providers/centreon-snippet-autogenerated.mdx
+++ b/docs/snippets/providers/centreon-snippet-autogenerated.mdx
@@ -13,6 +13,25 @@ Certain scopes may be required to perform specific actions or queries via the pr
 
 ## In workflows
 
-This provider can't be used as a "step" or "action" in workflows. If you want to use it, please let us know by creating an issue in the [GitHub repository](https://github.com/keephq/keep/issues).
+This provider can be used in workflows.
+
+As "action" to make changes or update data, example:
+```yaml
+actions:
+    - name: Acknowledge alert
+      provider: centreon
+      config: "{{ provider.my_provider_name }}"
+      with:
+        action: acknowledge_alert
+        host_id: {value}  # The host id.
+        service_id: {value}  # The service id (optional).
+        comment: {value}  # A comment for the acknowledgement.
+```
+
+
+## Provider Methods
+The provider exposes the following [Provider Methods](/providers/provider-methods#via-ai-assistant). They are available in the [AI Assistant](/overview/ai-incident-assistant).
+
+- **acknowledge_alert** Acknowledge a host or service alert (action, scopes: authenticated)
 
 

--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -5,6 +5,7 @@ Centreon is a class that provides a set of methods to interact with the Centreon
 import dataclasses
 import datetime
 
+import typing
 import pydantic
 import requests
 
@@ -252,6 +253,26 @@ class CentreonProvider(BaseProvider):
             raise ProviderException(
                 f"Error acknowledging alert in Centreon: {e}"
             ) from e
+
+    def _notify(
+        self,
+        action: typing.Literal["acknowledge_alert"] = "acknowledge_alert",
+        host_id: str = "",
+        service_id: str | None = None,
+        comment: str | None = None,
+        **kwargs: dict,
+    ) -> bool:
+        """Run Centreon actions.
+
+        Currently supports acknowledging alerts via ``acknowledge_alert``.
+        """
+
+        if action == "acknowledge_alert":
+            return self.acknowledge_alert(
+                host_id=host_id, service_id=service_id, comment=comment
+            )
+
+        raise NotImplementedError(f"Action {action} is not implemented")
 
     def _get_alerts(self) -> list[AlertDto]:
         alerts = []


### PR DESCRIPTION
## Summary
- add `_notify` to Centreon provider so it can acknowledge alerts via workflows
- update docs snippet to show the new action

## Testing
- `python3 scripts/docs_render_provider_snippets.py --validate` *(fails: ModuleNotFoundError)*
- `pre-commit run --files keep/providers/centreon_provider/centreon_provider.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842df7457a083288ac92d993954c0ac