### PR TITLE
Fix centreon provider annotation bug

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -106,7 +106,7 @@ class CentreonProvider(BaseProvider):
 
     @staticmethod
     def _format_host_alert(
-        host: dict, provider_instance: "BaseProvider" | None = None
+        host: dict, provider_instance: BaseProvider | None = None
     ) -> AlertDto:
         return AlertDto(
             id=host["id"],
@@ -128,7 +128,7 @@ class CentreonProvider(BaseProvider):
 
     @staticmethod
     def _format_service_alert(
-        service: dict, provider_instance: "BaseProvider" | None = None
+        service: dict, provider_instance: BaseProvider | None = None
     ) -> AlertDto:
         return AlertDto(
             id=service["service_id"],


### PR DESCRIPTION
## Summary
- remove quotes around `BaseProvider` union in Centreon provider

## Testing
- `ruff check keep/providers/centreon_provider/centreon_provider.py`
- `pytest -k centreon_provider -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_6842e349c3f0832895e0ccce2a7d6cd0