### PR TITLE
Fix Centreon pagination

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -167,6 +167,13 @@ class CentreonProvider(BaseProvider):
                 raise ProviderException(f"Failed to get {object_name} from Centreon")
 
             data = response.json()
+
+            # Some Centreon deployments wrap the results in a "result" or
+            # "data" key. Handle these cases transparently so pagination works
+            # regardless of the exact API version.
+            if isinstance(data, dict):
+                data = data.get("result") or data.get("data") or data.get(object_name) or []
+
             if not data:
                 break
 

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -38,6 +38,46 @@ class TestCentreonProvider(unittest.TestCase):
         self.assertEqual(alert.status, AlertStatus.FIRING)
         self.assertEqual(alert.severity, AlertSeverity.CRITICAL)
 
+    def test_get_paginated_data(self):
+        from unittest.mock import patch
+        from keep.contextmanager.contextmanager import ContextManager
+        from keep.providers.models.provider_config import ProviderConfig
+
+        context_manager = ContextManager(tenant_id="test")
+        provider = CentreonProvider(
+            context_manager,
+            provider_id="centreon",
+            config=ProviderConfig(
+                description="centreon",
+                authentication={"host_url": "http://localhost", "api_token": "t"},
+            ),
+        )
+
+        # Mock paginated responses: first page 50 items, second page 10 items
+        class MockResp:
+            def __init__(self, data):
+                self._data = data
+                self.ok = True
+                self.text = str(data)
+
+            def json(self):
+                return self._data
+
+        first_page = [
+            {"id": str(i), "address": "", "output": "", "state": 0, "instance_name": "i", "acknowledged": False, "max_check_attempts": 1, "last_check": 0}
+            for i in range(50)
+        ]
+        second_page = [
+            {"id": str(50 + i), "address": "", "output": "", "state": 0, "instance_name": "i", "acknowledged": False, "max_check_attempts": 1, "last_check": 0}
+            for i in range(10)
+        ]
+
+        with patch("keep.providers.centreon_provider.centreon_provider.requests.get") as mock_get:
+            mock_get.side_effect = [MockResp(first_page), MockResp(second_page)]
+            data = provider._CentreonProvider__get_paginated_data("centreon_realtime_hosts")
+            self.assertEqual(len(data), 60)
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- fix Centreon provider pagination for APIs returning wrapped result lists
- test pagination handling

## Testing
- `pytest -q tests/test_centreon_provider.py::TestCentreonProvider::test_get_paginated_data -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_6842e4e4c9ec83289e497d37769bfeb8