### PR TITLE
Update Centreon provider to API v2

### DIFF
--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -74,7 +74,7 @@ class TestCentreonProvider(unittest.TestCase):
 
         with patch("keep.providers.centreon_provider.centreon_provider.requests.get") as mock_get:
             mock_get.side_effect = [MockResp(first_page), MockResp(second_page)]
-            data = provider._CentreonProvider__get_paginated_data("centreon_realtime_hosts")
+            data = provider._CentreonProvider__get_paginated_data("monitoring/hosts")
             self.assertEqual(len(data), 60)
 
 


### PR DESCRIPTION
## Summary
- migrate Centreon provider to API v2 endpoints
- update acknowledgement call for API v2
- adapt pagination to new paths
- adjust tests for new API

## Testing
- `pre-commit` *(failed: command not found)*
- `pytest -k centreon_provider` *(failed: pyenv: version `3.11.1` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea8f6f788328a255bf721c53310f