### PR TITLE
Fix provider centreon param hints

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -341,7 +341,10 @@ class CentreonProvider(BaseProvider):
             ) from e
 
     def acknowledge_alert(
-        self, host_id: str, service_id: str | None = None, comment: str | None = None
+        self,
+        host_id: str,
+        service_id: str = None,
+        comment: str = None,
     ) -> bool:
         """Acknowledge a host or service alert in Centreon."""
 


### PR DESCRIPTION
## Summary
- revert provider factory changes that affected validation
- simplify Centreon `acknowledge_alert` parameter annotations

## Testing
- `ruff check keep/providers/providers_factory.py`
- `ruff check keep/providers/centreon_provider/centreon_provider.py`
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_68430209391c8328af6e203ff6a6a5d7