### PR TITLE
Fix Centreon acknowledgement fields

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -354,17 +354,17 @@ class CentreonProvider(BaseProvider):
         self,
         host_id: str,
         service_id: str = None,
-        comment: str = None,
+        comment: str | None = None,
     ) -> bool:
         """Acknowledge a host or service alert in Centreon."""
 
         try:
             payload = {
                 "author": "keep",
-                "comment": comment,
-                "notify": True,
-                "persistent": True,
-                "sticky": True,
+                "comment": comment or "Acknowledged via Keep",
+                "is_notify_contacts": False,
+                "is_persistent_comment": True,
+                "is_sticky": True,
             }
 
             if service_id:


### PR DESCRIPTION
## Summary
- use correct API field names when acknowledging alerts in Centreon
- add unit test for acknowledgement payload

## Testing
- `python -m pytest -q tests/test_centreon_provider.py::TestCentreonProvider::test_acknowledge_alert_payload -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684c5461edfc832898d7214c1260fcb8