### PR TITLE
Fix Centreon service alert key handling

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -231,8 +231,8 @@ class CentreonProvider(BaseProvider):
         service: dict, provider_instance: BaseProvider | None = None
     ) -> AlertDto:
         return AlertDto(
-            id=service["service_id"],
-            host_id=service["host_id"],
+            id=str(service.get("service_id") or service.get("id")),
+            host_id=service.get("host_id"),
             name=service["name"],
             description=service["description"],
             status=CentreonProvider.STATUS_MAP.get(

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -37,6 +37,22 @@ class TestCentreonProvider(unittest.TestCase):
         self.assertEqual(alert.status, AlertStatus.FIRING)
         self.assertEqual(alert.severity, AlertSeverity.CRITICAL)
 
+    def test_format_service_alert_with_id(self):
+        service = {
+            "id": "3",
+            "host_id": "1",
+            "name": "HTTPS",
+            "description": "https check",
+            "state": 1,
+            "output": "WARNING: slow",
+            "acknowledged": True,
+            "max_check_attempts": 5,
+            "last_check": 1700000001,
+        }
+        alert = CentreonProvider._format_service_alert(service)
+        self.assertEqual(alert.id, "3")
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+
     def test_get_paginated_data(self):
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- handle missing `service_id` key for Centreon service alerts
- test service alert formatting when only `id` is provided

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/test_centreon_provider.py` *(fails: Python 3.11.1 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c76895e5083288b9be2bd6f7f909e