### PR TITLE
Fix Centreon resource endpoint

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -258,14 +258,24 @@ class CentreonProvider(BaseProvider):
         status_code = status.get("code")
 
         return AlertDto(
-            id=str(resource.get("service_id") or resource.get("host_id") or resource.get("id")),
+            id=str(
+                resource.get("service_id")
+                or resource.get("host_id")
+                or resource.get("id")
+            ),
             host_id=resource.get("host_id"),
             service_id=resource.get("service_id"),
             name=resource.get("name"),
             description=resource.get("information"),
-            status=CentreonProvider.STATUS_MAP.get(status_code, AlertStatus.FIRING)
-            if status_code is not None
-            else (AlertStatus.RESOLVED if status_name in ("OK", "UP") else AlertStatus.FIRING),
+            status=(
+                CentreonProvider.STATUS_MAP.get(status_code, AlertStatus.FIRING)
+                if status_code is not None
+                else (
+                    AlertStatus.RESOLVED
+                    if status_name in ("OK", "UP")
+                    else AlertStatus.FIRING
+                )
+            ),
             severity=CentreonProvider.SEVERITY_MAP.get(status_name, AlertSeverity.INFO),
             acknowledged=resource.get("is_acknowledged"),
             lastReceived=resource.get("last_status_change")
@@ -385,7 +395,7 @@ class CentreonProvider(BaseProvider):
             ) from e
 
     def __get_resource_status(self) -> list[AlertDto]:
-        """Retrieve alerts from the unified ``monitoring/ressource`` endpoint."""
+        """Retrieve alerts from the unified ``monitoring/resources`` endpoint."""
 
         params = {
             "status_types": '["hard"]',
@@ -394,7 +404,7 @@ class CentreonProvider(BaseProvider):
         }
 
         try:
-            resources = self.__get_paginated_data("monitoring/ressource", params=params)
+            resources = self.__get_paginated_data("monitoring/resources", params=params)
             return [self._format_resource_alert(res, self) for res in resources]
         except Exception as e:
             self.logger.error("Error getting resource status from Centreon: %s", e)

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -172,9 +172,7 @@ class TestCentreonProvider(unittest.TestCase):
             called_url = mock_get.call_args[0][0]
             params = mock_get.call_args[1]["params"]
 
-            expected_url = (
-                "http://localhost/centreon/api/latest/monitoring/ressource"
-            )
+            expected_url = "http://localhost/centreon/api/latest/monitoring/resources"
             assert called_url == expected_url
             assert params["states"] == '["unhandled"]'
 


### PR DESCRIPTION
## Summary
- fix Centreon resource endpoint path
- update tests

## Testing
- `ruff check --fix keep/providers/centreon_provider/centreon_provider.py tests/test_centreon_provider.py`
- `black keep/providers/centreon_provider/centreon_provider.py tests/test_centreon_provider.py`
- `isort keep/providers/centreon_provider/centreon_provider.py tests/test_centreon_provider.py`
- `pytest tests/test_centreon_provider.py::TestCentreonProvider::test_get_resource_status_params -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684c78c84ca08328b4fcf966fbc444f7