### PR TITLE
Fix Centreon statuses parameter

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -405,7 +405,9 @@ class CentreonProvider(BaseProvider):
 
         params = {
             "status_types": '["hard"]',
-            "statuses": '["warning","down","unreachable","critical","unknown"]',
+            # Centreon expects status values in upper case
+            # see https://docs.centreon.com/api/
+            "status": '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]',
             "states": '["unhandled"]',
         }
 

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -175,6 +175,7 @@ class TestCentreonProvider(unittest.TestCase):
             expected_url = "http://localhost/centreon/api/latest/monitoring/resources"
             assert called_url == expected_url
             assert params["states"] == '["unhandled"]'
+            assert params["status"] == '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]'
 
     def test_acknowledge_alert_service_url(self):
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- use `status` parameter for monitoring resources
- verify `status` param in provider tests

## Testing
- `PYENV_VERSION=3.11.12 poetry run python -m pytest tests/test_centreon_provider.py::TestCentreonProvider::test_get_resource_status_params -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684c7f97d2d88328ae80798e87f1e12d