### PR TITLE
Fix Centreon resource query params

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -383,11 +383,17 @@ class CentreonProvider(BaseProvider):
         """Retrieve alerts from the unified ``monitoring/resources`` endpoint."""
 
         params = {
-            "status_types": '["hard"]',
+            "status_types": ["hard"],
             # Centreon expects status values in upper case
             # see https://docs.centreon.com/api/
-            "status": '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]',
-            "states": '["unhandled"]',
+            "status": [
+                "WARNING",
+                "DOWN",
+                "UNREACHABLE",
+                "CRITICAL",
+                "UNKNOWN",
+            ],
+            "state": ["unhandled"],
         }
 
         try:

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -174,8 +174,14 @@ class TestCentreonProvider(unittest.TestCase):
 
             expected_url = "http://localhost/centreon/api/latest/monitoring/resources"
             assert called_url == expected_url
-            assert params["states"] == '["unhandled"]'
-            assert params["status"] == '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]'
+            assert params["state"] == ["unhandled"]
+            assert params["status"] == [
+                "WARNING",
+                "DOWN",
+                "UNREACHABLE",
+                "CRITICAL",
+                "UNKNOWN",
+            ]
 
     def test_acknowledge_alert_service_url(self):
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- send arrays to Centreon API as lists
- update provider tests accordingly

## Testing
- `poetry run pytest -q tests/test_centreon_provider.py::TestCentreonProvider.test_get_resource_status_params` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684cfce7891483289744e14d6449fc01