### PR TITLE
Fix centreon provider resource query

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -386,7 +386,7 @@ class CentreonProvider(BaseProvider):
             "status_types": '["hard"]',
             # Centreon expects status values in upper case
             # see https://docs.centreon.com/api/
-            "status": '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]',
+            "statuses": '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]',
             "states": '["unhandled"]',
         }
 


### PR DESCRIPTION
## Summary
- fix query parameter for statuses when retrieving resources

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684cff04f5f48328851ce7dd4be6a786