### PR TITLE
Update Centreon state param

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -387,7 +387,7 @@ class CentreonProvider(BaseProvider):
             # Centreon expects status values in upper case
             # see https://docs.centreon.com/api/
             "status": '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]',
-            "states": '["unhandled"]',
+            "states": '["unhandled_problems"]',
         }
 
         try:

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -174,7 +174,7 @@ class TestCentreonProvider(unittest.TestCase):
 
             expected_url = "http://localhost/centreon/api/latest/monitoring/resources"
             assert called_url == expected_url
-            assert params["states"] == '["unhandled"]'
+            assert params["states"] == '["unhandled_problems"]'
             assert params["status"] == '["WARNING","DOWN","UNREACHABLE","CRITICAL","UNKNOWN"]'
 
     def test_acknowledge_alert_service_url(self):


### PR DESCRIPTION
## Summary
- fix Centreon provider to request only `unhandled_problems`
- update tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mysql')*
- `pre-commit run --files keep/providers/centreon_provider/centreon_provider.py tests/test_centreon_provider.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d006878a083289c24e579a2ff27c5