### PR TITLE
Fix Centreon status mapping

### DIFF
--- a/keep/providers/centreon_provider/centreon_provider.py
+++ b/keep/providers/centreon_provider/centreon_provider.py
@@ -81,14 +81,31 @@ class CentreonProvider(BaseProvider):
     ]
 
     """
-  Centreon only supports the following host state (UP = 0, DOWN = 2, UNREA = 3)
-  https://docs.centreon.com/docs/api/rest-api-v1/#realtime-information
-  """
+    Mapping of Centreon host/service state codes to Keep alert statuses.
+
+    According to the Centreon API documentation the following status codes are
+    used:
+
+    Host status codes:
+        * ``0`` - UP
+        * ``1`` - DOWN
+        * ``2`` - UNREACHABLE
+
+    Service status codes:
+        * ``0`` - OK
+        * ``1`` - WARNING
+        * ``2`` - CRITICAL
+        * ``3`` - UNKNOWN
+
+    Any non-zero state represents a problem so it maps to ``AlertStatus.FIRING``
+    while ``0`` means the resource is healthy and maps to ``AlertStatus.RESOLVED``.
+    """
 
     STATUS_MAP = {
+        0: AlertStatus.RESOLVED,
+        1: AlertStatus.FIRING,
         2: AlertStatus.FIRING,
         3: AlertStatus.FIRING,
-        0: AlertStatus.RESOLVED,
     }
 
     SEVERITY_MAP = {

--- a/tests/test_centreon_provider.py
+++ b/tests/test_centreon_provider.py
@@ -21,6 +21,21 @@ class TestCentreonProvider(unittest.TestCase):
         self.assertEqual(alert.status, AlertStatus.RESOLVED)
         self.assertEqual(alert.severity, AlertSeverity.LOW)
 
+    def test_format_host_alert_down(self):
+        host = {
+            "id": "2",
+            "name": "db2",
+            "address": "10.0.0.2",
+            "output": "DOWN",
+            "state": 1,
+            "instance_name": "inst2",
+            "acknowledged": False,
+            "max_check_attempts": 3,
+            "last_check": 1700000000,
+        }
+        alert = CentreonProvider._format_host_alert(host)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
+
     def test_format_service_alert(self):
         service = {
             "service_id": "2",
@@ -36,6 +51,21 @@ class TestCentreonProvider(unittest.TestCase):
         alert = CentreonProvider._format_service_alert(service)
         self.assertEqual(alert.status, AlertStatus.FIRING)
         self.assertEqual(alert.severity, AlertSeverity.CRITICAL)
+
+    def test_format_service_alert_unknown(self):
+        service = {
+            "service_id": "4",
+            "host_id": "1",
+            "name": "Disk",
+            "description": "disk check",
+            "state": 3,
+            "output": "UNKNOWN: ?",
+            "acknowledged": False,
+            "max_check_attempts": 3,
+            "last_check": 1700000000,
+        }
+        alert = CentreonProvider._format_service_alert(service)
+        self.assertEqual(alert.status, AlertStatus.FIRING)
 
     def test_format_service_alert_with_id(self):
         service = {


### PR DESCRIPTION
## Summary
- map all Centreon state codes to Keep alert statuses
- add unit tests for DOWN hosts and UNKNOWN services

## Testing
- `pytest -k centreon_provider -q` *(fails: ModuleNotFoundError: No module named 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_684d026ea9b88328a319839e648c6cbe